### PR TITLE
fix: wrong anchor in page perspective/voice

### DIFF
--- a/_perspective-videos/voice.md
+++ b/_perspective-videos/voice.md
@@ -70,7 +70,7 @@ Learn more {#resources}
     -   [Provide meaning for non-standard interactive
         elements]({{ "/tips/developing/" | relative_url }}#provide-meaning-for-non-standard-interactive-elements)
     -   [Provide alternative text for
-        images]({{ "/tips/designing/" | relative_url }}#provide-alternative-text-for-images)
+        images]({{ "/tips/designing/" | relative_url }}#include-image-and-media-alternatives-in-your-design)
 -   **Easy Check:**
     -   [Keyboard access and visual
         focus]({{ "/test-evaluate/preliminary/" | relative_url }}#interaction)


### PR DESCRIPTION
This should fix the wrong anchor in the link "Provide alternative text for images" in [https://www.w3.org/WAI/perspective-videos/voice/](https://www.w3.org/WAI/perspective-videos/voice/)

should resolve #10 