### PR TITLE
Fix link to customizable video in color contrast docs

### DIFF
--- a/_perspective-videos/contrast.md
+++ b/_perspective-videos/contrast.md
@@ -56,7 +56,7 @@ Select text and background colors that provide sufficient contrast.
 There are tools to help check and select appropriate color combinations.
 This is ideally done during the early design stage and the selection of
 color palettes. While some people need high contrast, some people are
-sensitive to brightness and need to [change the colors](perspective-videos/customizable/).
+sensitive to brightness and need to [change the colors](./customizable/).
 
 ## Learn more
 {:#resources}

--- a/_perspective-videos/contrast.md
+++ b/_perspective-videos/contrast.md
@@ -56,7 +56,7 @@ Select text and background colors that provide sufficient contrast.
 There are tools to help check and select appropriate color combinations.
 This is ideally done during the early design stage and the selection of
 color palettes. While some people need high contrast, some people are
-sensitive to brightness and need to [change the colors](./customizable/).
+sensitive to brightness and need to [change the colors](/perspective-videos/customizable/).
 
 ## Learn more
 {:#resources}


### PR DESCRIPTION
I think this fixes it but hard to test! It should go here though: https://www.w3.org/WAI/perspective-videos/customizable/