### PR TITLE
Use default layout instead of sidenav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ defaults:
     scope:
       path: "_perspective-videos"
     values:
-      layout: "sidenav"
+      layout: "default"
 
 plugins:
   - jekyll-seo-tag


### PR DESCRIPTION
This commit aims to set the `layout` default value to `default` instead of `sidenav`

Context:
- Currently, the `sidenav` layout is set to default for all files in the `_perspective-videos` folder
- That creates problems with the navigation look in Netlify previews (different from live website). Example here: https://deploy-preview-42--wai-perspective-videos.netlify.app/perspective-videos/
- And that does not work well with translations.
Example:
![sidenav_nav_issues_translations](https://github.com/w3c/wai-perspective-videos/assets/7482063/127c12b1-14d1-40b8-bb5d-da0bd73c5c0a)
- In the `wai-website` repository, the `default` layout is the default layout for this collection since 2018, [see this commit](https://github.com/w3c/wai-website/commit/00fef1261d67cd840bc35dedf458105f65d47d14)
 

